### PR TITLE
exploiters: Fix extraction of container IP address

### DIFF
--- a/automatic_exploit_generation/exploiters/zeratool/zeratool.py
+++ b/automatic_exploit_generation/exploiters/zeratool/zeratool.py
@@ -75,15 +75,27 @@ class Zeratool(BaseExploiter):
             publish_all_ports=True,
         )
 
-        container.reload()
-        container_ip = container.attrs["NetworkSettings"]["IPAddress"]
-        exploit = self._request_exploitation_to_grpc_service(
-            container_ip, overflow_only, format_only, win_funcs
-        )
+        try:
+            container.reload()
+            network_settings = container.attrs.get("NetworkSettings", {})
+            networks = network_settings.get("Networks", {})
+            if "bridge" in networks:
+                container_ip = (networks.get("bridge", {}) or {}).get("IPAddress")
+            elif networks:
+                container_ip = (next(iter(networks.values())) or {}).get("IPAddress")
+            else:
+                container_ip = network_settings.get("IPAddress")
+            if not container_ip:
+                container.kill()
+                raise RuntimeError("Could not determine container IP address.")
+            exploit = self._request_exploitation_to_grpc_service(
+                container_ip, overflow_only, format_only, win_funcs
+            )
 
-        container.kill()
+            return exploit
 
-        return exploit
+        finally:
+            container.kill()
 
     def _request_exploitation_to_grpc_service(
         self,


### PR DESCRIPTION
The JSON structure for the container IP address is not correct. Update to the current (potentially new) path in the JSON schema when inspecting a container.